### PR TITLE
fix: blog count

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,13 +22,14 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/facebook/docusaurus/edit/main/website/',
+          editUrl: 'https://github.com/yzeng25/yzeng25.github.io',
         },
         blog: {
+          blogSidebarCount: 'ALL',
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/facebook/docusaurus/edit/main/website/blog/',
+            'https://github.com/yzeng25/yzeng25.github.io',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Modify the blog sidebar, default shows only 5 blogs, now I have 6.

Add `blogSidebarCount: 'ALL'` in `docusaurus.config.js` to show **all** posts

ref: https://docusaurus.io/docs/blog#blog-sidebar